### PR TITLE
replaced 'cues' with 'queues'

### DIFF
--- a/docs/Topic_InteractiveAnimations.md
+++ b/docs/Topic_InteractiveAnimations.md
@@ -64,7 +64,7 @@ Animatable.animate(String variable, double target, long duration, Easing easing)
 
 ```
 
-Animatable.animate() cues a single animation for a single value. An animation consists of a target value and a duration and optionally a method of easing the animation.
+Animatable.animate() queues a single animation for a single value. An animation consists of a target value and a duration and optionally a method of easing the animation.
 
 In cases in which the target value is unknown but the increment is known one can use Animatable.add()
 


### PR DESCRIPTION
Hi

I'm new to OPENRNDR so this is a 'test' PR.

The word **queue** is easily confused with **cue**. One of the meanings of **cue** is a _signal/indicator/prompt/hint_, whereas the text  discusses the act of putting an Animation item in a queue. 
Apologies if you find this pedantic but it caused me some doubt as I was trying to make sense of the _Animatable_ class.

NB! This mistake is repeated quite a few times in the API doc (comments in the sourcecode). Hehe, I'm not ready to submit a PR for those just yet!

Regards




