### PR TITLE
Fixing index of rendertarget

### DIFF
--- a/docs/06_Advanced_drawing/C00_Render_targets_and_color_buffers.md
+++ b/docs/06_Advanced_drawing/C00_Render_targets_and_color_buffers.md
@@ -115,7 +115,7 @@ program {
         }
         // -- draw the backing color buffer to the screen
         drawer.image(rt0.colorBuffer(0))
-        drawer.image(rt1.colorBuffer(1))
+        drawer.image(rt1.colorBuffer(0))
     }
 }
 ```


### PR DESCRIPTION
Example did not work as rt1 has only one colorbuffer.