### PR TITLE
Composition drawer docs v1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ group 'org.openrndr.guide'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.4.10'
 
     repositories {
         jcenter()
@@ -12,9 +12,9 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        //classpath 'com.github.openrndr:dokgen:96e77e1cbb'
-        classpath 'org.openrndr:dokgen:1.0-SNAPSHOT'
-        classpath "org.ajoberstar:gradle-git-publish:2.0.0"
+        classpath 'com.github.openrndr:dokgen:96e77e1cbb'
+//        classpath 'org.openrndr:dokgen:1.0-SNAPSHOT'
+        classpath "org.ajoberstar:gradle-git-publish:2.1.3"
     }
 }
 
@@ -31,8 +31,8 @@ compileKotlin {
 }
 
 sourceCompatibility = 1.8
-project.ext.openrndrVersion = "0.3.43-rc.13"
-project.ext.orxVersion = "0.3.52-rc.4"
+project.ext.openrndrVersion = "0.3.45-rc.4"
+project.ext.orxVersion = "0.3.55-rc.3"
 
 repositories {
     mavenCentral()
@@ -57,6 +57,7 @@ switch (org.gradle.internal.os.OperatingSystem.current()) {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     runtime "org.openrndr:openrndr-gl3:$openrndrVersion"
     runtime "org.openrndr:openrndr-gl3-natives-$openrndrOS:$openrndrVersion"
@@ -67,8 +68,8 @@ dependencies {
     compile "org.openrndr:openrndr-filter:$openrndrVersion"
     compile "org.openrndr:openrndr-ffmpeg:$openrndrVersion"
 
-    //implementation 'com.github.openrndr:dokgen:96e77e1cbb'
-    implementation 'org.openrndr:dokgen:1.0-SNAPSHOT'
+    implementation 'com.github.openrndr:dokgen:96e77e1cbb'
+//    implementation 'org.openrndr:dokgen:1.0-SNAPSHOT'
 
     compile "org.openrndr.extra:orx-noise:$orxVersion"
     compile "org.openrndr.extra:orx-midi:$orxVersion"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip

--- a/src/main/kotlin/docs/04_Drawing_basics/C05_ComplexShapes.kt
+++ b/src/main/kotlin/docs/04_Drawing_basics/C05_ComplexShapes.kt
@@ -3,11 +3,15 @@ package docs.`04_Drawing_basics`
 import org.openrndr.application
 import org.openrndr.color.ColorRGBa
 import org.openrndr.dokgen.annotations.*
+import org.openrndr.draw.LineCap
 import org.openrndr.extensions.SingleScreenshot
+import org.openrndr.extra.noise.random
 import org.openrndr.ffmpeg.ScreenRecorder
 import org.openrndr.math.Vector2
 import org.openrndr.shape.*
 import kotlin.math.cos
+import kotlin.math.sin
+import java.lang.Math.toRadians
 
 
 fun main(args: Array<String>) {
@@ -122,7 +126,7 @@ _outline_ of the shape, and one for the _hole_ in the shape
 """
 
     @Text """## Shape Boolean-operations"""
-    @Text """Boolean-operations can be performed on shapes using the `compound {}` builder. There are three kinds
+    @Text """Boolean-operations can be performed on shapes using the `drawComposition {}` builder. There are three kinds
 of compounds: _union_, _difference_ and _intersection_, all three of them are shown in the example below.
 
     """.trimMargin()
@@ -141,39 +145,31 @@ of compounds: _union_, _difference_ and _intersection_, all three of them are sh
                 outputFile = "media/shapes-003.png"
             }
             extend {
-                drawer.fill = ColorRGBa.PINK
-                drawer.stroke = null
-                // -- shape union
-                val su = compound {
-                    union {
-                        shape(Circle(185.0, height / 2.0 - 80.0, 100.0).shape)
-                        shape(Circle(185.0, height / 2.0 + 80.0, 100.0).shape)
-                    }
+                val composition = drawComposition {
+                    fill = ColorRGBa.PINK
+                    stroke = null
+                    // -- shape union
+                    shape(union(
+                            Circle(185.0, height / 2.0 - 80.0, 100.0).shape,
+                            Circle(185.0, height / 2.0 + 80.0, 100.0).shape
+                    ))
+                    // -- shape difference
+                    shape(difference(
+                            Circle(385.0, height / 2.0 - 80.0, 100.0).shape,
+                            Circle(385.0, height / 2.0 + 80.0, 100.0).shape
+                    ))
+                    // -- shape intersection
+                    shape(intersection(
+                            Circle(585.0, height / 2.0 - 80.0, 100.0).shape,
+                            Circle(585.0, height / 2.0 + 80.0, 100.0).shape
+                    ))
                 }
-                drawer.shapes(su)
-
-                // -- shape difference
-                val sd = compound {
-                    difference {
-                        shape(Circle(385.0, height / 2.0 - 80.0, 100.0).shape)
-                        shape(Circle(385.0, height / 2.0 + 80.0, 100.0).shape)
-                    }
-                }
-                drawer.shapes(sd)
-
-                // -- shape intersection
-                val si = compound {
-                    intersection {
-                        shape(Circle(585.0, height / 2.0 - 80.0, 100.0).shape)
-                        shape(Circle(585.0, height / 2.0 + 80.0, 100.0).shape)
-                    }
-                }
-                drawer.shapes(si)
+                drawer.composition(composition)
             }
         }
     }
-    @Text """The _compound builder_ is actually a bit more clever than what the previous example demonstrated because
-it can actually work with an entire tree of compounds. Demonstrated below is the _union_ of two _intersections_.
+    @Text """The _composition drawer_ is actually a bit more clever than what the previous example demonstrated because
+it can actually work with an entire lists of shapes. Demonstrated below is the combination of several _intersections_.
 """
 
     @Media.Image """media/shapes-004.png"""
@@ -191,24 +187,73 @@ it can actually work with an entire tree of compounds. Demonstrated below is the
                 outputFile = "media/shapes-004.png"
             }
             extend {
-                drawer.fill = ColorRGBa.PINK
-                drawer.stroke = null
-                val cross = compound {
-                    union {
-                        intersection {
-                            shape(Circle(width / 2.0 - 160.0, height / 2.0, 200.0).shape)
-                            shape(Circle(width / 2.0 + 160.0, height / 2.0, 200.0).shape)
-                        }
-                        intersection {
-                            shape(Circle(width / 2.0, height / 2.0 - 160.0, 200.0).shape)
-                            shape(Circle(width / 2.0, height / 2.0 + 160.0, 200.0).shape)
-                        }
+                val drawingCenter = Vector2(width * 0.5, height * 0.5)
+                val cross = drawComposition {
+                    fill = ColorRGBa.PINK
+                    stroke = null
+                    val flower = (0 until 360 step 45).map { degrees ->
+                        val center1 = drawingCenter +
+                                Vector2(cos(toRadians(degrees.toDouble())), sin(toRadians(degrees.toDouble()))) * 70.0
+                        val center2 = drawingCenter +
+                                Vector2(cos(toRadians(degrees - 45.0)), sin(toRadians(degrees - 45.0))) * 70.0
+                        intersection(
+                                Circle(center1, 65.0).shape,
+                                Circle(center2, 65.0).shape
+                        )
                     }
+                    shapes(flower)
                 }
-                drawer.shapes(cross)
+                drawer.composition(cross)
             }
         }
     }
+
+    @Text """`ShapeContour`s can be used in conjunction with `Shape`s to create complex clipping patterns.
+Demonstrated below is the _intersection_ of multiple `contours` and a `Circle`.
+"""
+
+    @Media.Image """media/shapes-007.png"""
+
+    @Application
+    application {
+        configure {
+            width = 770
+            height = 578
+        }
+        @Code
+        program {
+            @Exclude
+            extend(SingleScreenshot()) {
+                outputFile = "media/shapes-007.png"
+            }
+            val center = Vector2(width * 0.5, height * 0.5)
+            val circle = Circle(center, 200.0)
+            val sineWaves = drawComposition {
+                val sine = { x: Double, y: Double -> Vector2(x, y + sin(x / 50.0) * 10.0) }
+                stroke = ColorRGBa.PINK
+                strokeWeight = 4.0
+                for (y in -50..height step 20) {
+                    val cs = contours {
+                        moveTo(sine(0.0, y.toDouble()))
+                        for (x in 0..width step 10) {
+                            if (random() < -0.5) {
+                                moveTo(sine(x.toDouble(), cursor.y))
+                            } else {
+                                lineTo(sine(x.toDouble(), cursor.y))
+                            }
+                        }
+                    }
+                    cs.forEach { shape(intersection(it, circle.shape)) }
+                }
+                shape(circle.shape)
+            }
+            extend {
+                drawer.lineCap = LineCap.ROUND
+                drawer.composition(sineWaves)
+            }
+        }
+    }
+
     @Text """## Cutting contours"""
     @Text """A contour be cut into a shorter contour using `ShapeContour.sub()`.""".trimMargin()
 

--- a/src/main/kotlin/docs/11_Advanced_Topics/C05_Lowlevel_drawing.kt
+++ b/src/main/kotlin/docs/11_Advanced_Topics/C05_Lowlevel_drawing.kt
@@ -94,7 +94,7 @@ In the following example we show the minimum steps required for drawing a single
             }                                                                
             """
 
-            val shader = Shader.createFromCode(vs, fs, name="custom-shader")
+            val shader = Shader.createFromCode(vsCode = vs, fsCode = fs, name="custom-shader")
 
             extend {
                 shader.begin()


### PR DESCRIPTION
OK this ended up being a much larger change than I realized. The API I was writing docs for wouldn't even compile with the existing versions of kotlin, gradle, openrndr, etc, so I bumped a bunch of dependencies.

Note: this is **not complete** because the examples do not all compile, due to API changes. However, the areas that are broken are a bit outside my domain of knowledge, so I'm posting here as a way of sharing info. This PR can be amended by others or just used as a base, whatever is convenient.

Current errors when running `./gradlew dokgen`

```
e: /Users/eric/dev/openrndr-guide/src/main/kotlin/docs/11_Advanced_Topics/C06_Compute_shaders.kt: (65, 41): Type mismatch: inferred type is ColorBuffer but ImageBinding was expected

e: /Users/eric/dev/openrndr-guide/src/main/kotlin/docs/11_Advanced_Topics/C06_Compute_shaders.kt: (65, 51): Too many arguments for public abstract fun image(name: String, image: Int, imageBinding: ImageBinding): Unit defined in org.openrndr.draw.ComputeShader

e: /Users/eric/dev/openrndr-guide/src/main/kotlin/docs/11_Advanced_Topics/C06_Compute_shaders.kt: (66, 42): Type mismatch: inferred type is ColorBuffer but ImageBinding was expected

e: /Users/eric/dev/openrndr-guide/src/main/kotlin/docs/11_Advanced_Topics/C06_Compute_shaders.kt: (66, 50): Too many arguments for public abstract fun image(name: String, image: Int, imageBinding: ImageBinding): Unit defined in org.openrndr.draw.ComputeShader
```

Coming from [these two lines of code](https://github.com/openrndr/openrndr-guide/blob/dev/src/main/kotlin/docs/11_Advanced_Topics/C06_Compute_shaders.kt#L65-L66)
