### PR TITLE
Fix grayscale images description

### DIFF
--- a/src/main/kotlin/docs/04_Drawing_basics/C110_Images.kt
+++ b/src/main/kotlin/docs/04_Drawing_basics/C110_Images.kt
@@ -199,7 +199,7 @@ fun main() {
     """
     ### Grayscale
     
-    Drawing an image with inverted colors can be achieved by using the `grayscale` color matrix.
+    Drawing an image in grayscale can be achieved by using the `grayscale` color matrix.
     """
 
     @Media.Image "../media/image-006.jpg"


### PR DESCRIPTION
I noticed an error in the description about drawing images in grayscale. I suppose it's a copy-paste error from the previous paragraph about drawing images with inverted colors.