### PR TITLE
Fix page about Transformations

### DIFF
--- a/src/main/kotlin/docs/05_Drawing_and_transformations/C100_Transformations.kt
+++ b/src/main/kotlin/docs/05_Drawing_and_transformations/C100_Transformations.kt
@@ -272,7 +272,7 @@ fun main() {
     In the snippet below a `Matrix44` instance is constructed using the `transform {}` builder. Note that the application order is from bottom to top.
     
     ```kotlin
-    drawer.view *= transform {
+    drawer.model *= transform {
         rotate(32.0)
         rotate(Vector3(1.0, 1.0, 0.0).normalized, 43.0)
         translate(4.0, 2.0)

--- a/src/main/kotlin/docs/05_Drawing_and_transformations/C100_Transformations.kt
+++ b/src/main/kotlin/docs/05_Drawing_and_transformations/C100_Transformations.kt
@@ -291,7 +291,7 @@ fun main() {
     ## Applying transforms to vectors
     
     ```kotlin
-        val x = Vector3(1.0, 2.0, 3.0, 1.0)
+        val x = Vector4(1.0, 2.0, 3.0, 1.0)
         val m = transform {
             rotate(Vector3.UNIT_Y, 42.0)
         }

--- a/src/main/kotlin/docs/05_Drawing_and_transformations/C100_Transformations.kt
+++ b/src/main/kotlin/docs/05_Drawing_and_transformations/C100_Transformations.kt
@@ -238,7 +238,6 @@ fun main() {
     `fun rotate(…)`      | `model`
     `fun translate(…)`   | `model`
     `fun scale(…)`       | `model`
-    `fun rotate(…)`      | `model`
     `fun lookAt(…)`      | `view`
     `fun ortho(…)`       | `projection`
     `fun perspective(…)` | `projection`


### PR DESCRIPTION
I think I found some errors in the "Transformations" page, but I'm not 100% sure about them. Could you check if my corrections make sense?

In particular, I changed `drawer.view` to `drawer.model` because the table in the same page says that the `rotate`, `translate` and `scale` operations affect the `model` matrix, not the `view` matrix.